### PR TITLE
Use libopus-dev 1.3.1 from Ubuntu 19.04 (Disco)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,12 @@ ENV TZ="UTC"
 
 RUN echo $TZ > /etc/timezone \
     # Avoid ERROR: invoke-rc.d: policy-rc.d denied execution of start.
-    && sed -i "s/^exit 101$/exit 0/" /usr/sbin/policy-rc.d 
+    && sed -i "s/^exit 101$/exit 0/" /usr/sbin/policy-rc.d
+
+COPY disco.list /etc/apt/sources.list.d/disco.list
+COPY disco /etc/apt/preferences.d/disco
+
+RUN apt-cache policy libopus-dev
     
 # Common packages
 RUN apt-get update \

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,9 @@ RUN echo $TZ > /etc/timezone \
     # Avoid ERROR: invoke-rc.d: policy-rc.d denied execution of start.
     && sed -i "s/^exit 101$/exit 0/" /usr/sbin/policy-rc.d
 
+# Use newer 19.04 sources to get a newer version of libopus-dev
 COPY disco.list /etc/apt/sources.list.d/disco.list
 COPY disco /etc/apt/preferences.d/disco
-
 RUN apt-cache policy libopus-dev
     
 # Common packages

--- a/disco
+++ b/disco
@@ -1,0 +1,11 @@
+Package: *
+Pin: release v=19.04, -l=Ubuntu
+Pin-Priority: 10
+
+Package: libopus-dev
+Pin: release v=19.04, -l=Ubuntu
+Pin-Priority: 990
+
+Package: libopus0
+Pin: release v=19.04, -l=Ubuntu
+Pin-Priority: 990

--- a/disco.list
+++ b/disco.list
@@ -1,0 +1,2 @@
+deb http://archive.ubuntu.com/ubuntu/ disco main restricted universe multiverse
+deb-src http://archive.ubuntu.com/ubuntu/ disco main restricted universe multiverse


### PR DESCRIPTION
This PR adds the 19.04 sources to the image but pins all packages of that version to a lower priority than the ones from 18.04 thus preventing them from being installed. The `libopus-dev` and `libopus0` packages are pinned to a higher priority so that they will be installed from 19.04. The configuration files are named after the os version name of Ubuntu 19.04, Disco Dingo.

This PR relates to [this issue](https://github.com/AzuraCast/AzuraCast/issues/1478) from the AzuraCast repository.