### PR TITLE
Update to Liquidsoap 2.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN opam init --disable-sandboxing -a --bare && opam switch create 4.12.0
 RUN cd ~/ \
      && git clone --recursive https://github.com/savonet/liquidsoap.git \
     && cd liquidsoap \
-    && git checkout bd9a2e3531ec03bae4f2812b6d83bdacf2277f0c \
+    && git checkout 43aa734dd37595e991ad7d8d9b8560e7d47c19fe \
     && opam pin add --no-action liquidsoap .
 
 ARG opam_packages="ladspa.0.2.0 ffmpeg.1.0.1 ffmpeg-avutil.1.0.1 ffmpeg-avcodec.1.0.1 ffmpeg-avdevice.1.0.1 ffmpeg-av.1.0.1 ffmpeg-avfilter.1.0.1 ffmpeg-swresample.1.0.1 ffmpeg-swscale.1.0.1 frei0r.0.1.2 samplerate.0.1.6 taglib.0.3.6 mad.0.5.0 faad.0.5.0 fdkaac.0.3.2 lame.0.3.4 vorbis.0.8.0 cry.0.6.5 flac.0.3.0 opus.0.2.0 dtools.0.4.4 duppy.0.9.2 ocurl.0.9.1 ssl liquidsoap"

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,10 +41,10 @@ RUN opam init --disable-sandboxing -a --bare && opam switch create 4.12.0
 RUN cd ~/ \
      && git clone --recursive https://github.com/savonet/liquidsoap.git \
     && cd liquidsoap \
-    && git checkout d99a5c7acbfd76e4a598bf703885d81e482bbcca \
+    && git checkout bb61734bcb3b844352a496b7e5a21129d78badc5 \
     && opam pin add --no-action liquidsoap .
 
-ARG opam_packages="ladspa.0.2.0 ffmpeg.1.0.0~beta2 samplerate.0.1.6 taglib.0.3.6 mad.0.5.0 faad.0.5.0 fdkaac.0.3.2 lame.0.3.4 vorbis.0.8.0 cry.0.6.5 flac.0.3.0 opus.0.2.0 duppy.0.9.2 ocurl.0.9.1 ssl liquidsoap"
+ARG opam_packages="ladspa.0.2.0 ffmpeg.1.0.0~rc1 samplerate.0.1.6 taglib.0.3.6 mad.0.5.0 faad.0.5.0 fdkaac.0.3.2 lame.0.3.4 vorbis.0.8.0 cry.0.6.5 flac.0.3.0 opus.0.2.0 duppy.0.9.2 ocurl.0.9.1 ssl liquidsoap"
 RUN opam install -y ${opam_packages}
 
 #

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,16 +35,16 @@ RUN apt-get update \
 
 USER azuracast
 
-RUN opam init --disable-sandboxing -a --bare && opam switch create ocaml-system.4.08.1 
+RUN opam init --disable-sandboxing -a --bare && opam switch create ocaml-system.4.08.1
 
 # Uncomment to Pin specific commit of Liquidsoap
 RUN cd ~/ \
      && git clone --recursive https://github.com/savonet/liquidsoap.git \
     && cd liquidsoap \
-    && git checkout 75d530c86bf638e3c50c08b7802d92270288e31b \
+    && git checkout 6fc002dd8c27ea4d6849ac3078662d53fd484106 \
     && opam pin add --no-action liquidsoap .
 
-ARG opam_packages="ladspa.0.1.5 ffmpeg.0.4.3 samplerate.0.1.4 taglib.0.3.3 mad.0.4.5 faad.0.4.0 fdkaac.0.3.1 lame.0.3.3 vorbis.0.7.1 cry.0.6.1 flac.0.1.5 opus.0.1.3 duppy.0.8.0 ssl liquidsoap"
+ARG opam_packages="ladspa.0.2.0 ffmpeg.0.4.3 samplerate.0.1.5 taglib.0.3.6 mad.0.5.0 faad.0.5.0 fdkaac.0.3.2 lame.0.3.4 vorbis.0.8.0 cry.0.6.5 flac.0.3.0 opus.0.2.0 duppy.0.9.0 ssl liquidsoap"
 RUN opam install -y ${opam_packages}
 
 #

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ FROM base AS liquidsoap
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -q -y --no-install-recommends \
         build-essential libssl-dev libcurl4-openssl-dev bubblewrap unzip m4 software-properties-common \
-        ocaml opam \
+        ocaml opam ffmpeg \
         autoconf automake
 
 USER azuracast
@@ -42,9 +42,17 @@ RUN cd ~/ \
      && git clone --recursive https://github.com/savonet/liquidsoap.git \
     && cd liquidsoap \
     && git checkout bb61734bcb3b844352a496b7e5a21129d78badc5 \
+    && opam pin add --no-action ffmpeg https://github.com/savonet/ocaml-ffmpeg.git#70e6af941586ce196e7e771e1dd0f7b8f99e84de \
+    && opam pin add --no-action ffmpeg-avutil https://github.com/savonet/ocaml-ffmpeg.git#70e6af941586ce196e7e771e1dd0f7b8f99e84de \
+    && opam pin add --no-action ffmpeg-avcodec https://github.com/savonet/ocaml-ffmpeg.git#70e6af941586ce196e7e771e1dd0f7b8f99e84de \
+    && opam pin add --no-action ffmpeg-avdevice https://github.com/savonet/ocaml-ffmpeg.git#70e6af941586ce196e7e771e1dd0f7b8f99e84de \
+    && opam pin add --no-action ffmpeg-av https://github.com/savonet/ocaml-ffmpeg.git#70e6af941586ce196e7e771e1dd0f7b8f99e84de \
+    && opam pin add --no-action ffmpeg-avfilter https://github.com/savonet/ocaml-ffmpeg.git#70e6af941586ce196e7e771e1dd0f7b8f99e84de \
+    && opam pin add --no-action ffmpeg-swresample https://github.com/savonet/ocaml-ffmpeg.git#70e6af941586ce196e7e771e1dd0f7b8f99e84de \
+    && opam pin add --no-action ffmpeg-swscale https://github.com/savonet/ocaml-ffmpeg.git#70e6af941586ce196e7e771e1dd0f7b8f99e84de \
     && opam pin add --no-action liquidsoap .
 
-ARG opam_packages="ladspa.0.2.0 ffmpeg.1.0.0~rc1 samplerate.0.1.6 taglib.0.3.6 mad.0.5.0 faad.0.5.0 fdkaac.0.3.2 lame.0.3.4 vorbis.0.8.0 cry.0.6.5 flac.0.3.0 opus.0.2.0 duppy.0.9.2 ocurl.0.9.1 ssl liquidsoap"
+ARG opam_packages="ladspa.0.2.0 ffmpeg.1.0.1 ffmpeg-avutil.1.0.1 ffmpeg-avcodec.1.0.1 ffmpeg-avdevice.1.0.1 ffmpeg-av.1.0.1 ffmpeg-avfilter.1.0.1 ffmpeg-swresample.1.0.1 ffmpeg-swscale.1.0.1 frei0r.0.1.2 samplerate.0.1.6 taglib.0.3.6 mad.0.5.0 faad.0.5.0 fdkaac.0.3.2 lame.0.3.4 vorbis.0.8.0 cry.0.6.5 flac.0.3.0 opus.0.2.0 dtools.0.4.4 duppy.0.9.2 ocurl.0.9.1 ssl liquidsoap"
 RUN opam install -y ${opam_packages}
 
 #

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,16 +35,17 @@ RUN apt-get update \
 
 USER azuracast
 
-RUN opam init --disable-sandboxing -a --bare && opam switch create ocaml-system.4.08.1
+RUN opam init --disable-sandboxing -a --bare && opam switch create 4.12.0
 
 # Uncomment to Pin specific commit of Liquidsoap
 RUN cd ~/ \
      && git clone --recursive https://github.com/savonet/liquidsoap.git \
     && cd liquidsoap \
     && git checkout 6fc002dd8c27ea4d6849ac3078662d53fd484106 \
+    && opam pin add --no-action ffmpeg https://github.com/savonet/ocaml-ffmpeg.git#a5d6effd5fe9e53689ac45a620f9349a79e14e78 \
     && opam pin add --no-action liquidsoap .
 
-ARG opam_packages="ladspa.0.2.0 ffmpeg.0.4.3 samplerate.0.1.5 taglib.0.3.6 mad.0.5.0 faad.0.5.0 fdkaac.0.3.2 lame.0.3.4 vorbis.0.8.0 cry.0.6.5 flac.0.3.0 opus.0.2.0 duppy.0.9.0 ssl liquidsoap"
+ARG opam_packages="ladspa.0.2.0 samplerate.0.1.5 taglib.0.3.6 mad.0.5.0 faad.0.5.0 fdkaac.0.3.2 lame.0.3.4 vorbis.0.8.0 cry.0.6.5 flac.0.3.0 opus.0.2.0 duppy.0.9.0 ocurl.0.9.1 ffmpeg.1.0.0-beta1 ssl liquidsoap"
 RUN opam install -y ${opam_packages}
 
 #

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,10 +41,10 @@ RUN opam init --disable-sandboxing -a --bare && opam switch create 4.12.0
 RUN cd ~/ \
      && git clone --recursive https://github.com/savonet/liquidsoap.git \
     && cd liquidsoap \
-    && git checkout ee13f438861148c8ea415bdf6707dfd555c99ec8 \
+    && git checkout d99a5c7acbfd76e4a598bf703885d81e482bbcca \
     && opam pin add --no-action liquidsoap .
 
-ARG opam_packages="ladspa.0.2.0 ffmpeg.1.0.0~beta1 samplerate.0.1.5 taglib.0.3.6 mad.0.5.0 faad.0.5.0 fdkaac.0.3.2 lame.0.3.4 vorbis.0.8.0 cry.0.6.5 flac.0.3.0 opus.0.2.0 duppy.0.9.2 ocurl.0.9.1 ssl liquidsoap"
+ARG opam_packages="ladspa.0.2.0 ffmpeg.1.0.0~beta2 samplerate.0.1.6 taglib.0.3.6 mad.0.5.0 faad.0.5.0 fdkaac.0.3.2 lame.0.3.4 vorbis.0.8.0 cry.0.6.5 flac.0.3.0 opus.0.2.0 duppy.0.9.2 ocurl.0.9.1 ssl liquidsoap"
 RUN opam install -y ${opam_packages}
 
 #

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN opam init --disable-sandboxing -a --bare && opam switch create 4.12.0
 RUN cd ~/ \
      && git clone --recursive https://github.com/savonet/liquidsoap.git \
     && cd liquidsoap \
-    && git checkout f0ec18b495a576b84dc9dfa74e85ec5d15208dbb \
+    && git checkout ee13f438861148c8ea415bdf6707dfd555c99ec8 \
     && opam pin add --no-action liquidsoap .
 
 ARG opam_packages="ladspa.0.2.0 ffmpeg.1.0.0~beta1 samplerate.0.1.5 taglib.0.3.6 mad.0.5.0 faad.0.5.0 fdkaac.0.3.2 lame.0.3.4 vorbis.0.8.0 cry.0.6.5 flac.0.3.0 opus.0.2.0 duppy.0.9.2 ocurl.0.9.1 ssl liquidsoap"

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,15 +41,7 @@ RUN opam init --disable-sandboxing -a --bare && opam switch create 4.12.0
 RUN cd ~/ \
      && git clone --recursive https://github.com/savonet/liquidsoap.git \
     && cd liquidsoap \
-    && git checkout bb61734bcb3b844352a496b7e5a21129d78badc5 \
-    && opam pin add --no-action ffmpeg https://github.com/savonet/ocaml-ffmpeg.git#70e6af941586ce196e7e771e1dd0f7b8f99e84de \
-    && opam pin add --no-action ffmpeg-avutil https://github.com/savonet/ocaml-ffmpeg.git#70e6af941586ce196e7e771e1dd0f7b8f99e84de \
-    && opam pin add --no-action ffmpeg-avcodec https://github.com/savonet/ocaml-ffmpeg.git#70e6af941586ce196e7e771e1dd0f7b8f99e84de \
-    && opam pin add --no-action ffmpeg-avdevice https://github.com/savonet/ocaml-ffmpeg.git#70e6af941586ce196e7e771e1dd0f7b8f99e84de \
-    && opam pin add --no-action ffmpeg-av https://github.com/savonet/ocaml-ffmpeg.git#70e6af941586ce196e7e771e1dd0f7b8f99e84de \
-    && opam pin add --no-action ffmpeg-avfilter https://github.com/savonet/ocaml-ffmpeg.git#70e6af941586ce196e7e771e1dd0f7b8f99e84de \
-    && opam pin add --no-action ffmpeg-swresample https://github.com/savonet/ocaml-ffmpeg.git#70e6af941586ce196e7e771e1dd0f7b8f99e84de \
-    && opam pin add --no-action ffmpeg-swscale https://github.com/savonet/ocaml-ffmpeg.git#70e6af941586ce196e7e771e1dd0f7b8f99e84de \
+    && git checkout bd9a2e3531ec03bae4f2812b6d83bdacf2277f0c \
     && opam pin add --no-action liquidsoap .
 
 ARG opam_packages="ladspa.0.2.0 ffmpeg.1.0.1 ffmpeg-avutil.1.0.1 ffmpeg-avcodec.1.0.1 ffmpeg-avdevice.1.0.1 ffmpeg-av.1.0.1 ffmpeg-avfilter.1.0.1 ffmpeg-swresample.1.0.1 ffmpeg-swscale.1.0.1 frei0r.0.1.2 samplerate.0.1.6 taglib.0.3.6 mad.0.5.0 faad.0.5.0 fdkaac.0.3.2 lame.0.3.4 vorbis.0.8.0 cry.0.6.5 flac.0.3.0 opus.0.2.0 dtools.0.4.4 duppy.0.9.2 ocurl.0.9.1 ssl liquidsoap"

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,11 +41,10 @@ RUN opam init --disable-sandboxing -a --bare && opam switch create 4.12.0
 RUN cd ~/ \
      && git clone --recursive https://github.com/savonet/liquidsoap.git \
     && cd liquidsoap \
-    && git checkout 6fc002dd8c27ea4d6849ac3078662d53fd484106 \
-    && opam pin add --no-action ffmpeg https://github.com/savonet/ocaml-ffmpeg.git#a5d6effd5fe9e53689ac45a620f9349a79e14e78 \
+    && git checkout f0ec18b495a576b84dc9dfa74e85ec5d15208dbb \
     && opam pin add --no-action liquidsoap .
 
-ARG opam_packages="ladspa.0.2.0 samplerate.0.1.5 taglib.0.3.6 mad.0.5.0 faad.0.5.0 fdkaac.0.3.2 lame.0.3.4 vorbis.0.8.0 cry.0.6.5 flac.0.3.0 opus.0.2.0 duppy.0.9.0 ocurl.0.9.1 ffmpeg.1.0.0-beta1 ssl liquidsoap"
+ARG opam_packages="ladspa.0.2.0 ffmpeg.1.0.0~beta1 samplerate.0.1.5 taglib.0.3.6 mad.0.5.0 faad.0.5.0 fdkaac.0.3.2 lame.0.3.4 vorbis.0.8.0 cry.0.6.5 flac.0.3.0 opus.0.2.0 duppy.0.9.2 ocurl.0.9.1 ssl liquidsoap"
 RUN opam install -y ${opam_packages}
 
 #
@@ -58,9 +57,9 @@ COPY --from=icecast /usr/local/bin/icecast /usr/local/bin/icecast
 COPY --from=icecast /usr/local/share/icecast /usr/local/share/icecast
 
 # Import Liquidsoap from build container
-COPY --from=liquidsoap --chown=azuracast:azuracast /var/azuracast/.opam/ocaml-system.4.08.1 /var/azuracast/.opam/ocaml-system.4.08.1
+COPY --from=liquidsoap --chown=azuracast:azuracast /var/azuracast/.opam/4.12.0 /var/azuracast/.opam/4.12.0
 
-RUN ln -s /var/azuracast/.opam/ocaml-system.4.08.1/bin/liquidsoap /usr/local/bin/liquidsoap
+RUN ln -s /var/azuracast/.opam/4.12.0/bin/liquidsoap /usr/local/bin/liquidsoap
 
 EXPOSE 9001
 EXPOSE 8000-8999

--- a/build/setup/liquidsoap.sh
+++ b/build/setup/liquidsoap.sh
@@ -5,6 +5,6 @@ set -x
 
 # Only install Liquidsoap deps (Liquidsoap build is handled by another container).
 $minimal_apt_get_install libfaad-dev libfdk-aac-dev libflac-dev libmad0-dev libmp3lame-dev libogg-dev \
-    libopus-dev libpcre3-dev libtag1-dev libsamplerate0-dev libavcodec-dev libavfilter-dev \
-    libavformat-dev libavresample-dev libavutil-dev libpostproc-dev libswresample-dev \
+    libopus-dev libpcre3-dev libtag1-dev libsamplerate0-dev libavcodec-dev libavdevice-dev libavfilter-dev \
+    libavformat-dev libavresample-dev libavutil-dev libpostproc-dev libswresample-dev libswscale-dev \
     ladspa-sdk multimedia-audio-plugins swh-plugins tap-plugins lsp-plugins-ladspa

--- a/build/setup/liquidsoap.sh
+++ b/build/setup/liquidsoap.sh
@@ -7,4 +7,4 @@ set -x
 $minimal_apt_get_install libfaad-dev libfdk-aac-dev libflac-dev libmad0-dev libmp3lame-dev libogg-dev \
     libopus-dev libpcre3-dev libtag1-dev libsamplerate0-dev libavcodec-dev libavdevice-dev libavfilter-dev \
     libavformat-dev libavresample-dev libavutil-dev libpostproc-dev libswresample-dev libswscale-dev \
-    ladspa-sdk multimedia-audio-plugins swh-plugins tap-plugins lsp-plugins-ladspa
+    frei0r-plugins-dev ladspa-sdk multimedia-audio-plugins swh-plugins tap-plugins lsp-plugins-ladspa


### PR DESCRIPTION
This PR updates the AzuraCast radio docker container to use the Liquidsoap 2.0.0 beta on the latest commit.

I have also prepared a PR for the AzuraCast application with an updated Liquidsoap ConfigWriter that makes the configuration generated by the application compatible with the deprecations and changes in Liquidsoap 2.0.0.

I have created this as a draft PR in order to gather feedback and prepare for the transition when Liquidsoap 2.0.0 is released.