### PR TITLE
Move FFmpeg from build to base dependencies

### DIFF
--- a/build/setup/liquidsoap.sh
+++ b/build/setup/liquidsoap.sh
@@ -8,7 +8,7 @@ $minimal_apt_get_install libao-dev libasound2-dev libavcodec-dev libavdevice-dev
     libavutil-dev libfaad-dev libfdk-aac-dev libflac-dev libfreetype-dev libgd-dev libjack-dev \
     libjpeg-dev liblo-dev libmad0-dev libmagic-dev libmp3lame-dev libopus-dev libpng-dev libportaudio2 \
     libpulse-dev libsamplerate0-dev libsdl2-dev libsdl2-ttf-dev libsdl2-image-dev libshine-dev libsoundtouch-dev libspeex-dev \
-    libsrt-dev libswresample-dev libswscale-dev libtag1-dev libtheora-dev libtiff-dev libx11-dev libxpm-dev bubblewrap
+    libsrt-dev libswresample-dev libswscale-dev libtag1-dev libtheora-dev libtiff-dev libx11-dev libxpm-dev bubblewrap ffmpeg
 
 # Optional audio plugins
 $minimal_apt_get_install frei0r-plugins-dev ladspa-sdk multimedia-audio-plugins swh-plugins tap-plugins lsp-plugins-ladspa

--- a/liquidsoap_amd64/build.sh
+++ b/liquidsoap_amd64/build.sh
@@ -6,7 +6,7 @@ apt-get update
 
 DEBIAN_FRONTEND=noninteractive apt-get install -q -y --no-install-recommends \
     build-essential libssl-dev libcurl4-openssl-dev bubblewrap unzip m4 software-properties-common \
-    ocaml opam ffmpeg \
+    ocaml opam \
     autoconf automake
 
 apt-get clean


### PR DESCRIPTION
**Fixes issue:**
First part of the fix for https://github.com/AzuraCast/AzuraCast/issues/2074

**Proposed changes:**
This PR moves the `ffmpeg` package from being a build only dependency to the base dependencies that will be present in the final image. This fixes an issue with Liquidsoap were it wasn't able to calculate the ReplayGain values of tracks due to it not finding an ffmpeg and ffprobe binary.
